### PR TITLE
Minor cleanups

### DIFF
--- a/ATSerial.cpp
+++ b/ATSerial.cpp
@@ -66,7 +66,7 @@ bool ATSerial::readResp(char* rsp)
 	 }
   }
   //delayMicroseconds(5000);
-  while(1) 
+  while(1)
   {
     cnt = 0;
     *rsp = (char)_uart->read();
@@ -75,7 +75,7 @@ bool ATSerial::readResp(char* rsp)
 
     if(len >= UART_MAX_LEN)
       break;
-    
+
     // wait upto 2000us for another character to become available
     while(!_uart->available())
     {
@@ -97,7 +97,7 @@ bool ATSerial::readResp(char* rsp)
  * @param resp_buffer char array of length UART_MAX_LEN+1 (513) to which response from device is written
  * @return whether the response begins with prefix
  */
-bool ATSerial::checkResponse(const char* prefix,char* resp_buffer) 
+bool ATSerial::checkResponse(const char* prefix,char* resp_buffer)
 {
   if(!readResp(resp_buffer)){
 	  return false;
@@ -118,7 +118,6 @@ bool ATSerial::checkResponse(const char* prefix,char* resp_buffer)
  */
 bool ATSerial::sendCmdAndCheckRsp(const char* cmd, const char* prefix, char* resp_buffer)
 {
-	bool ret = false;
 	uint8_t resend_cnt = 0;
 	ATWrite(cmd);
 	while(!checkResponse(prefix, resp_buffer)){
@@ -140,8 +139,6 @@ bool ATSerial::sendCmdAndCheckRsp(const char* cmd, const char* prefix, char* res
 bool ATSerial::waitForData(uint8_t *recv_msg,uint32_t *chars_read)
 {
   int recv_len = 0;
-  int i = 0;
-  int ch = 0;
   uint32_t milli = millis();
   while(!_uart->available()){
      if((millis() - milli) > _timeout){
@@ -174,7 +171,7 @@ int ATSerial::read(void) {
  * @return the number of bytes written
  */
 int ATSerial::ATWrite(const char* s) {
-  
+
   #if DEBUG_EN
   debug.print(F("Write ===>: "));
   debug.println(s);
@@ -203,14 +200,14 @@ int ATSerial::ATWrite(const char* s) {
 // }
 
 int ATSerial::ATWrite(const uint8_t uc) {
-  
+
   return _uart->write(uc);
 }
 
 
-void ATSerial::binWrite(uint8_t *msg,uint32_t len)
+void ATSerial::binWrite(uint8_t *msg, uint32_t len)
 {
-  for(int i=0;i<len;i++)
+  for(uint32_t i=0; i < len; i++)
   {
     _uart->write(msg[i]);
   }

--- a/w600.cpp
+++ b/w600.cpp
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <inttypes.h>
 
 #include "w600.h"
 #include <avr/pgmspace.h>
@@ -61,7 +62,7 @@ void AtWifi::begin(SoftwareSerial &uart,uint32_t baud)
 
 // bool AtWifi::wifiGetMode()
 // {
-//     return sendAT("AT+WPRT=!");   
+//     return sendAT("AT+WPRT=!");
 // }
 
 // bool AtWifi::wifiStaGetTargetApSsid()
@@ -185,7 +186,7 @@ bool AtWifi::wifiStaSetTargetApSsid(const __FlashStringHelper* ssid)
     strcpy_P(_cmd_buffer,PSTR("AT+SSID=!"));
     strcat_P(_cmd_buffer,(const char*)ssid);
     strcat(_cmd_buffer,AT_enter);
-    return ATSerial::sendCmdAndCheckRsp(_cmd_buffer,RSP_OK,_resp_buffer);  
+    return ATSerial::sendCmdAndCheckRsp(_cmd_buffer,RSP_OK,_resp_buffer);
 }
 
 bool AtWifi::wifiStaSetTargetApPswd(const __FlashStringHelper* password)
@@ -212,7 +213,7 @@ int AtWifi::wifiCreateSocketSTA(NetProtocol pro,NetMode mode,const char* server,
     sprintf_P(_cmd_buffer,PSTR("AT+SKCT=%d,%d,%s,%d,%d,%s"),pro,mode,server,remote_port,local_port,AT_enter);
     bool ok = ATSerial::sendCmdAndCheckRsp(_cmd_buffer,RSP_OK_equal,_resp_buffer);
     if (ok) {
-        return atoi(&_resp_buffer[4]); 
+        return atoi(&_resp_buffer[4]);
     } else {
         return -1;
     }
@@ -223,9 +224,9 @@ int AtWifi::wifiCreateSocketSTA(NetProtocol pro,NetMode mode,const char* server,
  * socket - socket number.
  * send - the string msg to send.
  * */
-bool AtWifi::wifiSocketSend(int32_t socket,const char* send) 
+bool AtWifi::wifiSocketSend(int32_t socket,const char* send)
 {
-    bool ret = wifiSocketPrepareSend(socket, strlen(send)); 
+    bool ret = wifiSocketPrepareSend(socket, strlen(send));
     if (ret) {
         ATSerial::flush();
         ATSerial::ATWrite(send);
@@ -235,11 +236,11 @@ bool AtWifi::wifiSocketSend(int32_t socket,const char* send)
 
 bool AtWifi::wifiSocketPrepareSend(int socket,int message_length)
 {
-    ATSerial::flush();   
+    ATSerial::flush();
     const char* fmt = PSTR("AT+SKSND=%d,%d,%s");
-    int buflen = snprintf_P(nullptr,0, fmt,socket,message_length,AT_enter); 
+    int buflen = snprintf_P(nullptr,0, fmt,socket,message_length,AT_enter);
     char buf[buflen];
-    sprintf_P(buf, fmt,socket,message_length,AT_enter); 
+    sprintf_P(buf, fmt,socket,message_length,AT_enter);
       #if DEBUG_EN
         debug.print(F("message_length:"));
         debug.println(message_length);
@@ -260,13 +261,13 @@ void AtWifi::write_P(const __FlashStringHelper* data){
  * each header must be terminated with \n
  * content must end with \n\n.
  ***/
-bool AtWifi::httpPost(
-    int socket, 
+void AtWifi::httpPost(
+    int socket,
     const __FlashStringHelper* post_url,
     const __FlashStringHelper* host,
-    const __FlashStringHelper* user_agent, 
-    const __FlashStringHelper* content_type, 
-    const __FlashStringHelper* opt_headers, 
+    const __FlashStringHelper* user_agent,
+    const __FlashStringHelper* content_type,
+    const __FlashStringHelper* opt_headers,
     char* content)
 {
    int header_len = strlen_P((const char*)post_url) + strlen_P((const char*)host) + strlen_P((const char*)content_type) + strlen_P((const char*)opt_headers) + strlen_P((const char*)user_agent);
@@ -274,7 +275,7 @@ bool AtWifi::httpPost(
    const char* fmt = PSTR("Content-Length: %d\n\n");
    int len_message_len = snprintf_P(nullptr,0,fmt,(content_len-2));//does not include the 2 newlines
    bool sent =  wifiSocketPrepareSend(socket,header_len + content_len + len_message_len);
-   
+
    if (sent){
         char buf[len_message_len];
         sprintf_P(buf,fmt,(content_len-2));
@@ -300,14 +301,14 @@ bool AtWifi::httpPost(
  * scoket - socket number
  * read_len - recv len.
  * */
-bool AtWifi::wifiSocketRead(int32_t socket,uint32_t read_len) //TODO is there a problem with types passed to sprintf_P here?
+bool AtWifi::wifiSocketRead(int32_t socket, uint32_t read_len) //TODO is there a problem with types passed to sprintf_P here?
 {
     ATSerial::flush();
-    sprintf_P(_cmd_buffer,PSTR("AT+SKRCV=%d,%d,%s"),socket,read_len,AT_enter);
+    sprintf_P(_cmd_buffer, PSTR("AT+SKRCV=%" PRId32 ",%" PRIu32 ",%s"), socket, read_len, AT_enter);
     return ATSerial::sendCmdAndCheckRsp(_cmd_buffer,RSP_OK_equal,_resp_buffer);
 }
 
-bool AtWifi::sendBinaryMsg(uint8_t *msg,uint32_t msg_len)
+void AtWifi::sendBinaryMsg(uint8_t *msg,uint32_t msg_len)
 {
     ATSerial::flush();
     ATSerial::binWrite(msg,msg_len);
@@ -360,7 +361,7 @@ bool AtWifi::recvData(uint8_t *recv_msg,uint32_t *len)
 // }
 
 
-// Code below contains code for operating in AP mode - ported from original seeed library and re-written to avoid Strings but untested. 
+// Code below contains code for operating in AP mode - ported from original seeed library and re-written to avoid Strings but untested.
 
 // /**Create a socket binding in AP mode.
 //  * msg - The socket number that module return.

--- a/w600.h
+++ b/w600.h
@@ -84,8 +84,8 @@ typedef enum
 
 typedef enum
 {
-    DISCONNECT = -1,           //Indicate that wifi module does not connect in sta mode or does not configure ok in AP mode. 
-    AP_MODE_SET_OK = 1,            //Indicate that wifi module runs in AP mode and configure ok! 
+    DISCONNECT = -1,           //Indicate that wifi module does not connect in sta mode or does not configure ok in AP mode.
+    AP_MODE_SET_OK = 1,            //Indicate that wifi module runs in AP mode and configure ok!
     STA_MODE_CONNECTED,        //Indicate that wifi module runs in STA mode and had connected a ap already.
     AP_STA_MODE_CONNECT_OK,    //Indicate that wifi module runs in STA&AP mode,and,AP configure ok & STA had connect to specifed ap.
 }WifiStatus;
@@ -109,7 +109,7 @@ class AtWifi:public ATSerial
 
         const char* buffer() const {return _resp_buffer;}
 
-        // Send an AT command. Returns true if response begins with +OK. 
+        // Send an AT command. Returns true if response begins with +OK.
         bool sendAT(const __FlashStringHelper* cmd);
 
         //Set wifi mode:1.station mode ,2.AP mode 3.station&AP mode.
@@ -118,7 +118,7 @@ class AtWifi:public ATSerial
         //Set target Ap ssid,Module work in STA or STA&AP mode.
         bool wifiStaSetTargetApSsid(const __FlashStringHelper* ssid);
 
-    
+
         //Set target Ap password,Module work in STA or STA&AP mode.
         bool wifiStaSetTargetApPswd(const __FlashStringHelper* password);
 
@@ -158,9 +158,9 @@ class AtWifi:public ATSerial
         * */
         bool wifiSocketRead(int32_t socket,uint32_t read_len);
 
-        bool httpPost(int socket, const __FlashStringHelper* post_url,const __FlashStringHelper* host,const __FlashStringHelper* user_agent, const __FlashStringHelper* content_type, const __FlashStringHelper* opt_headers, char* content);
+        void httpPost(int socket, const __FlashStringHelper* post_url,const __FlashStringHelper* host,const __FlashStringHelper* user_agent, const __FlashStringHelper* content_type, const __FlashStringHelper* opt_headers, char* content);
 
-        // AP mode: should ssid be broadcast? 
+        // AP mode: should ssid be broadcast?
         bool broadcastApSsidSet(bool flag);
 
 
@@ -177,7 +177,7 @@ class AtWifi:public ATSerial
         * */
         bool setWifiConfigMode(WifiConfig mode);
 
-        bool sendBinaryMsg(uint8_t *msg,uint32_t msg_len);
+        void sendBinaryMsg(uint8_t *msg,uint32_t msg_len);
         bool recvData(uint8_t *recv_msg,uint32_t *len);
         bool setBaudrate(uint32_t baud);
         bool getSpecSocketInfo(int32_t socket);


### PR DESCRIPTION
Hi,

This cleans up some compiler warnings for erroneous return types and type mismatches.
I did just notice that my editor removed some trailing whitespace in a couple of places, don't know if you care about that or not. I can always redo the pull request without that.

